### PR TITLE
Fix missing navbar

### DIFF
--- a/aikidorol.html
+++ b/aikidorol.html
@@ -50,5 +50,6 @@
         </div>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="dist/js/scripts.js"></script>
 </body>
 </html>

--- a/aikidorol_en.html
+++ b/aikidorol_en.html
@@ -50,5 +50,6 @@
         </div>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="dist/js/scripts.js"></script>
 </body>
 </html>

--- a/gallery.html
+++ b/gallery.html
@@ -47,5 +47,6 @@
         </div>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="dist/js/scripts.js"></script>
 </body>
 </html>

--- a/gallery_en.html
+++ b/gallery_en.html
@@ -47,5 +47,6 @@
         </div>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="dist/js/scripts.js"></script>
 </body>
 </html>

--- a/helyszin.html
+++ b/helyszin.html
@@ -69,5 +69,6 @@
         </div>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="dist/js/scripts.js"></script>
 </body>
 </html>

--- a/helyszin_en.html
+++ b/helyszin_en.html
@@ -62,5 +62,6 @@
         </div>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="dist/js/scripts.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -74,5 +74,6 @@
     </footer>
     <!-- Bootstrap core JS-->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="dist/js/scripts.js"></script>
 </body>
 </html>

--- a/index_en.html
+++ b/index_en.html
@@ -69,5 +69,6 @@
         </div>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="dist/js/scripts.js"></script>
 </body>
 </html>

--- a/jelentkezes.html
+++ b/jelentkezes.html
@@ -65,5 +65,6 @@
         </div>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="dist/js/scripts.js"></script>
 </body>
 </html>

--- a/jelentkezes_en.html
+++ b/jelentkezes_en.html
@@ -65,5 +65,6 @@
         </div>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="dist/js/scripts.js"></script>
 </body>
 </html>

--- a/kapcsolat.html
+++ b/kapcsolat.html
@@ -54,5 +54,6 @@
         </div>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="dist/js/scripts.js"></script>
 </body>
 </html>

--- a/kapcsolat_en.html
+++ b/kapcsolat_en.html
@@ -54,5 +54,6 @@
         </div>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="dist/js/scripts.js"></script>
 </body>
 </html>

--- a/praktikus.html
+++ b/praktikus.html
@@ -68,5 +68,6 @@
         </div>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="dist/js/scripts.js"></script>
 </body>
 </html>

--- a/praktikus_en.html
+++ b/praktikus_en.html
@@ -68,5 +68,6 @@
         </div>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="dist/js/scripts.js"></script>
 </body>
 </html>

--- a/rolunk.html
+++ b/rolunk.html
@@ -52,5 +52,6 @@
         </div>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="dist/js/scripts.js"></script>
 </body>
 </html>

--- a/rolunk_en.html
+++ b/rolunk_en.html
@@ -49,5 +49,6 @@
         </div>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="dist/js/scripts.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load `dist/js/scripts.js` in all pages to restore navbar

## Testing
- `grep -n "scripts.js" *.html`

------
https://chatgpt.com/codex/tasks/task_e_687c167e61148323836c5a059eeebd80