### PR TITLE
Implement SPA navigation

### DIFF
--- a/dist/js/scripts.js
+++ b/dist/js/scripts.js
@@ -4,25 +4,103 @@
 * Licensed under MIT (https://github.com/StartBootstrap/startbootstrap-clean-blog/blob/master/LICENSE)
 */
 window.addEventListener('DOMContentLoaded', () => {
-
-    const placeholder = document.getElementById('navbar-placeholder');
+    const getPlaceholder = () => document.getElementById('navbar-placeholder') || document.getElementById('mainNav');
     const lang = document.documentElement.lang;
-    if (placeholder) {
-        const navFile = lang === 'en' ? 'navbar_en.html' : 'navbar_hu.html';
-        fetch(navFile)
-            .then(response => response.text())
-            .then(html => {
-                placeholder.outerHTML = html;
+
+    const loadNav = (navFile) => {
+        return new Promise((resolve) => {
+            const target = getPlaceholder();
+            const cached = sessionStorage.getItem(navFile);
+            const finalize = (html) => {
+                if (target) {
+                    target.outerHTML = html;
+                }
                 const mainNav = document.getElementById('mainNav');
                 if (mainNav) {
                     mainNav.classList.add('sticky-top');
                 }
-            });
-    } else {
-        const mainNav = document.getElementById('mainNav');
-        if (mainNav) {
-            mainNav.classList.add('sticky-top');
-        }
+                resolve();
+            };
+            if (cached) {
+                finalize(cached);
+            } else {
+                fetch(navFile)
+                    .then(r => r.text())
+                    .then(html => {
+                        sessionStorage.setItem(navFile, html);
+                        finalize(html);
+                    });
+            }
+        });
+    };
 
-    }
+    const initSpa = () => {
+        const navLinks = document.querySelectorAll('#mainNav a.nav-link');
+        navLinks.forEach(link => {
+            link.addEventListener('click', (e) => {
+                const href = link.getAttribute('href');
+                if (href && !href.startsWith('http') && !href.startsWith('mailto:')) {
+                    e.preventDefault();
+                    navigate(href);
+                }
+            });
+        });
+
+        window.addEventListener('popstate', () => {
+            navigate(location.pathname.replace(/^\//, ''), true);
+        });
+    };
+
+    const updateActiveNav = (url) => {
+        const navLinks = document.querySelectorAll('#mainNav a.nav-link');
+        navLinks.forEach(link => {
+            if (link.getAttribute('href') === url) {
+                link.classList.add('active');
+            } else {
+                link.classList.remove('active');
+            }
+        });
+    };
+
+    const navigate = (url, replace) => {
+        fetch(url)
+            .then(r => r.text())
+            .then(html => {
+                const parser = new DOMParser();
+                const doc = parser.parseFromString(html, 'text/html');
+
+                const newHeader = doc.querySelector('header');
+                const newMain = doc.querySelector('main');
+                const header = document.querySelector('header');
+                const main = document.querySelector('main');
+
+                if (newHeader && header) header.replaceWith(newHeader);
+                if (newMain && main) main.replaceWith(newMain);
+
+                document.title = doc.title;
+                const newDesc = doc.querySelector('meta[name="description"]');
+                const desc = document.querySelector('meta[name="description"]');
+                if (newDesc && desc) desc.setAttribute('content', newDesc.getAttribute('content'));
+
+                const newLang = doc.documentElement.lang;
+                if (newLang !== document.documentElement.lang) {
+                    document.documentElement.lang = newLang;
+                    const navFile = newLang === 'en' ? 'navbar_en.html' : 'navbar_hu.html';
+                    loadNav(navFile).then(initSpa);
+                } else {
+                    updateActiveNav(url);
+                }
+
+                if (!replace) {
+                    history.pushState({}, '', url);
+                }
+                window.scrollTo(0, 0);
+            });
+    };
+
+    const navFile = lang === 'en' ? 'navbar_en.html' : 'navbar_hu.html';
+    loadNav(navFile).then(() => {
+        initSpa();
+        updateActiveNav(location.pathname.replace(/^\//, '') || 'index.html');
+    });
 });


### PR DESCRIPTION
## Summary
- rewrite navbar loader to cache markup
- add client-side routing so the navbar doesn't reload

## Testing
- `node -e "console.log('syntax ok')" && node dist/js/scripts.js >/tmp/out.log && cat /tmp/out.log` *(fails: window not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687c1a9f573483239c7a3fb393b86c61