### PR TITLE
Unify masthead heading markup

### DIFF
--- a/dist/css/styles.css
+++ b/dist/css/styles.css
@@ -10688,21 +10688,17 @@ header.masthead:before {
   opacity: 0.5;
 }
 header.masthead .page-heading,
-header.masthead .post-heading,
-header.masthead .site-heading {
+header.masthead .post-heading {
   color: #fff;
 }
-header.masthead .page-heading,
-header.masthead .site-heading {
+header.masthead .page-heading {
   text-align: center;
 }
-header.masthead .page-heading h1, header.masthead .page-heading .h1,
-header.masthead .site-heading h1,
-header.masthead .site-heading .h1 {
+header.masthead .page-heading h1,
+header.masthead .page-heading .h1 {
   font-size: 3rem;
 }
-header.masthead .page-heading .subheading,
-header.masthead .site-heading .subheading {
+header.masthead .page-heading .subheading {
   font-size: 1.5rem;
   font-weight: 300;
   line-height: 1.1;
@@ -10738,9 +10734,8 @@ header.masthead .post-heading .meta a {
     padding-top: 12.5rem;
     padding-bottom: 12.5rem;
   }
-  header.masthead .page-heading h1, header.masthead .page-heading .h1,
-  header.masthead .site-heading h1,
-  header.masthead .site-heading .h1 {
+  header.masthead .page-heading h1,
+  header.masthead .page-heading .h1 {
     font-size: 5rem;
   }
   header.masthead .post-heading h1, header.masthead .post-heading .h1 {

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         <div class="container position-relative px-4 px-lg-5">
             <div class="row gx-4 gx-lg-5 justify-content-center">
                 <div class="col-md-10 col-lg-8 col-xl-7">
-                    <div class="site-heading">
+                    <div class="page-heading">
                         <h1>Misogi Aikido Dojo</h1>
                         <span class="subheading">Szeptemberben új felnőtt kezdő csoport indul</span>
                     </div>

--- a/index_en.html
+++ b/index_en.html
@@ -19,7 +19,7 @@
         <div class="container position-relative px-4 px-lg-5">
             <div class="row gx-4 gx-lg-5 justify-content-center">
                 <div class="col-md-10 col-lg-8 col-xl-7">
-                    <div class="site-heading">
+                    <div class="page-heading">
                         <h1>Misogi Aikido Dojo</h1>
                         <span class="subheading">New beginner class starts in September</span>
                     </div>


### PR DESCRIPTION
## Summary
- switch homepage mastheads to use `page-heading`
- drop unused `site-heading` CSS rules

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c2b761e3c8323af1123c87380b8d3