### PR TITLE
Remove masthead headers

### DIFF
--- a/aikidorol.html
+++ b/aikidorol.html
@@ -14,18 +14,10 @@
 <body>
 
 <div id="navbar-placeholder"></div>
+<div class='container px-4 px-lg-5 text-center my-4'>
+    <h1>Aikidóról</h1>
+</div>
 
-    <header class="masthead" style="background-image: url('assets/img/default-bg.jpg')">
-        <div class="container position-relative px-4 px-lg-5">
-            <div class="row gx-4 gx-lg-5 justify-content-center">
-                <div class="col-md-10 col-lg-8 col-xl-7">
-                    <div class="page-heading">
-                        <h1>Aikidóról</h1>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </header>
     <main>
         <div class="container px-4 px-lg-5">
             <div class="row gx-4 gx-lg-5 justify-content-center">

--- a/aikidorol_en.html
+++ b/aikidorol_en.html
@@ -14,18 +14,10 @@
 <body>
 
 <div id="navbar-placeholder"></div>
+<div class='container px-4 px-lg-5 text-center my-4'>
+    <h1>About Aikido</h1>
+</div>
 
-    <header class="masthead" style="background-image: url('assets/img/default-bg.jpg')">
-        <div class="container position-relative px-4 px-lg-5">
-            <div class="row gx-4 gx-lg-5 justify-content-center">
-                <div class="col-md-10 col-lg-8 col-xl-7">
-                    <div class="page-heading">
-                        <h1>About Aikido</h1>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </header>
     <main>
         <div class="container px-4 px-lg-5">
             <div class="row gx-4 gx-lg-5 justify-content-center">

--- a/gallery.html
+++ b/gallery.html
@@ -14,18 +14,10 @@
 <body>
 
 <div id="navbar-placeholder"></div>
+<div class='container px-4 px-lg-5 text-center my-4'>
+    <h1>Galéria</h1>
+</div>
 
-    <header class="masthead" style="background-image: url('assets/img/default-bg.jpg')">
-        <div class="container position-relative px-4 px-lg-5">
-            <div class="row gx-4 gx-lg-5 justify-content-center">
-                <div class="col-md-10 col-lg-8 col-xl-7">
-                    <div class="page-heading">
-                        <h1>Galéria</h1>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </header>
     <main>
         <div class="container px-4 px-lg-5">
             <div class="row gx-4 gx-lg-5 justify-content-center">

--- a/gallery_en.html
+++ b/gallery_en.html
@@ -14,18 +14,10 @@
 <body>
 
 <div id="navbar-placeholder"></div>
+<div class='container px-4 px-lg-5 text-center my-4'>
+    <h1>Gallery</h1>
+</div>
 
-    <header class="masthead" style="background-image: url('assets/img/default-bg.jpg')">
-        <div class="container position-relative px-4 px-lg-5">
-            <div class="row gx-4 gx-lg-5 justify-content-center">
-                <div class="col-md-10 col-lg-8 col-xl-7">
-                    <div class="page-heading">
-                        <h1>Gallery</h1>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </header>
     <main>
         <div class="container px-4 px-lg-5">
             <div class="row gx-4 gx-lg-5 justify-content-center">

--- a/helyszin.html
+++ b/helyszin.html
@@ -14,18 +14,10 @@
 <body>
 
 <div id="navbar-placeholder"></div>
+<div class='container px-4 px-lg-5 text-center my-4'>
+    <h1>Helyszín</h1>
+</div>
 
-    <header class="masthead" style="background-image: url('assets/img/default-bg.jpg')">
-        <div class="container position-relative px-4 px-lg-5">
-            <div class="row gx-4 gx-lg-5 justify-content-center">
-                <div class="col-md-10 col-lg-8 col-xl-7">
-                    <div class="page-heading">
-                        <h1>Helyszín</h1>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </header>
     <main>
         <div class="container px-4 px-lg-5">
             <div class="row gx-4 gx-lg-5 justify-content-center">

--- a/helyszin_en.html
+++ b/helyszin_en.html
@@ -14,18 +14,10 @@
 <body>
 
 <div id="navbar-placeholder"></div>
+<div class='container px-4 px-lg-5 text-center my-4'>
+    <h1>Location</h1>
+</div>
 
-    <header class="masthead" style="background-image: url('assets/img/default-bg.jpg')">
-        <div class="container position-relative px-4 px-lg-5">
-            <div class="row gx-4 gx-lg-5 justify-content-center">
-                <div class="col-md-10 col-lg-8 col-xl-7">
-                    <div class="page-heading">
-                        <h1>Location</h1>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </header>
     <main>
         <div class="container px-4 px-lg-5">
             <div class="row gx-4 gx-lg-5 justify-content-center">

--- a/index.html
+++ b/index.html
@@ -15,20 +15,11 @@
     <!-- Navigation-->
 
 <div id="navbar-placeholder"></div>
+<div class='container px-4 px-lg-5 text-center my-4'>
+    <h1>Misogi Aikido Dojo</h1>
+    <p>Szeptemberben új felnőtt kezdő csoport indul</p>
+</div>
 
-    <!-- Page Header-->
-    <header class="masthead" style="background-image: url('assets/img/home-bg.jpg')">
-        <div class="container position-relative px-4 px-lg-5">
-            <div class="row gx-4 gx-lg-5 justify-content-center">
-                <div class="col-md-10 col-lg-8 col-xl-7">
-                    <div class="page-heading">
-                        <h1>Misogi Aikido Dojo</h1>
-                        <span class="subheading">Szeptemberben új felnőtt kezdő csoport indul</span>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </header>
     <!-- Main Content-->
     <main>
         <div class="container px-4 px-lg-5">

--- a/index_en.html
+++ b/index_en.html
@@ -14,19 +14,11 @@
 <body>
 
 <div id="navbar-placeholder"></div>
+<div class='container px-4 px-lg-5 text-center my-4'>
+    <h1>Misogi Aikido Dojo</h1>
+    <p>New beginner class starts in September</p>
+</div>
 
-    <header class="masthead" style="background-image: url('assets/img/home-bg.jpg')">
-        <div class="container position-relative px-4 px-lg-5">
-            <div class="row gx-4 gx-lg-5 justify-content-center">
-                <div class="col-md-10 col-lg-8 col-xl-7">
-                    <div class="page-heading">
-                        <h1>Misogi Aikido Dojo</h1>
-                        <span class="subheading">New beginner class starts in September</span>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </header>
     <main>
         <div class="container px-4 px-lg-5">
             <div class="row gx-4 gx-lg-5 justify-content-center">

--- a/jelentkezes.html
+++ b/jelentkezes.html
@@ -14,18 +14,10 @@
 <body>
 
 <div id="navbar-placeholder"></div>
+<div class='container px-4 px-lg-5 text-center my-4'>
+    <h1>Jelentkezés</h1>
+</div>
 
-    <header class="masthead" style="background-image: url('assets/img/default-bg.jpg')">
-        <div class="container position-relative px-4 px-lg-5">
-            <div class="row gx-4 gx-lg-5 justify-content-center">
-                <div class="col-md-10 col-lg-8 col-xl-7">
-                    <div class="page-heading">
-                        <h1>Jelentkezés</h1>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </header>
     <main>
         <div class="container px-4 px-lg-5">
             <div class="row gx-4 gx-lg-5 justify-content-center">

--- a/jelentkezes_en.html
+++ b/jelentkezes_en.html
@@ -14,18 +14,10 @@
 <body>
 
 <div id="navbar-placeholder"></div>
+<div class='container px-4 px-lg-5 text-center my-4'>
+    <h1>Application</h1>
+</div>
 
-    <header class="masthead" style="background-image: url('assets/img/default-bg.jpg')">
-        <div class="container position-relative px-4 px-lg-5">
-            <div class="row gx-4 gx-lg-5 justify-content-center">
-                <div class="col-md-10 col-lg-8 col-xl-7">
-                    <div class="page-heading">
-                        <h1>Application</h1>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </header>
     <main>
         <div class="container px-4 px-lg-5">
             <div class="row gx-4 gx-lg-5 justify-content-center">

--- a/kapcsolat.html
+++ b/kapcsolat.html
@@ -14,18 +14,10 @@
 <body>
 
 <div id="navbar-placeholder"></div>
+<div class='container px-4 px-lg-5 text-center my-4'>
+    <h1>Kapcsolat</h1>
+</div>
 
-    <header class="masthead" style="background-image: url('assets/img/default-bg.jpg')">
-        <div class="container position-relative px-4 px-lg-5">
-            <div class="row gx-4 gx-lg-5 justify-content-center">
-                <div class="col-md-10 col-lg-8 col-xl-7">
-                    <div class="page-heading">
-                        <h1>Kapcsolat</h1>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </header>
     <main>
         <div class="container px-4 px-lg-5">
             <div class="row gx-4 gx-lg-5 justify-content-center">

--- a/kapcsolat_en.html
+++ b/kapcsolat_en.html
@@ -14,18 +14,10 @@
 <body>
 
 <div id="navbar-placeholder"></div>
+<div class='container px-4 px-lg-5 text-center my-4'>
+    <h1>Contact</h1>
+</div>
 
-    <header class="masthead" style="background-image: url('assets/img/default-bg.jpg')">
-        <div class="container position-relative px-4 px-lg-5">
-            <div class="row gx-4 gx-lg-5 justify-content-center">
-                <div class="col-md-10 col-lg-8 col-xl-7">
-                    <div class="page-heading">
-                        <h1>Contact</h1>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </header>
     <main>
         <div class="container px-4 px-lg-5">
             <div class="row gx-4 gx-lg-5 justify-content-center">

--- a/praktikus.html
+++ b/praktikus.html
@@ -14,18 +14,10 @@
 <body>
 
 <div id="navbar-placeholder"></div>
+<div class='container px-4 px-lg-5 text-center my-4'>
+    <h1>Praktikus kérdések</h1>
+</div>
 
-    <header class="masthead" style="background-image: url('assets/img/default-bg.jpg')">
-        <div class="container position-relative px-4 px-lg-5">
-            <div class="row gx-4 gx-lg-5 justify-content-center">
-                <div class="col-md-10 col-lg-8 col-xl-7">
-                    <div class="page-heading">
-                        <h1>Praktikus kérdések</h1>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </header>
     <main>
         <div class="container px-4 px-lg-5">
             <div class="row gx-4 gx-lg-5 justify-content-center">

--- a/praktikus_en.html
+++ b/praktikus_en.html
@@ -14,18 +14,10 @@
 <body>
 
 <div id="navbar-placeholder"></div>
+<div class='container px-4 px-lg-5 text-center my-4'>
+    <h1>Practical questions</h1>
+</div>
 
-    <header class="masthead" style="background-image: url('assets/img/default-bg.jpg')">
-        <div class="container position-relative px-4 px-lg-5">
-            <div class="row gx-4 gx-lg-5 justify-content-center">
-                <div class="col-md-10 col-lg-8 col-xl-7">
-                    <div class="page-heading">
-                        <h1>Practical questions</h1>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </header>
     <main>
         <div class="container px-4 px-lg-5">
             <div class="row gx-4 gx-lg-5 justify-content-center">

--- a/rolunk.html
+++ b/rolunk.html
@@ -15,19 +15,10 @@
     <!-- Navigation-->
 
 <div id="navbar-placeholder"></div>
+<div class='container px-4 px-lg-5 text-center my-4'>
+    <h1>Rólunk</h1>
+</div>
 
-    <!-- Page Header-->
-    <header class="masthead" style="background-image: url('assets/img/default-bg.jpg')">
-        <div class="container position-relative px-4 px-lg-5">
-            <div class="row gx-4 gx-lg-5 justify-content-center">
-                <div class="col-md-10 col-lg-8 col-xl-7">
-                    <div class="page-heading">
-                        <h1>Rólunk</h1>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </header>
     <!-- Main Content-->
     <main>
         <div class="container px-4 px-lg-5">

--- a/rolunk_en.html
+++ b/rolunk_en.html
@@ -14,18 +14,10 @@
 <body>
 
 <div id="navbar-placeholder"></div>
+<div class='container px-4 px-lg-5 text-center my-4'>
+    <h1>About Us</h1>
+</div>
 
-    <header class="masthead" style="background-image: url('assets/img/default-bg.jpg')">
-        <div class="container position-relative px-4 px-lg-5">
-            <div class="row gx-4 gx-lg-5 justify-content-center">
-                <div class="col-md-10 col-lg-8 col-xl-7">
-                    <div class="page-heading">
-                        <h1>About Us</h1>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </header>
     <main>
         <div class="container px-4 px-lg-5">
             <div class="row gx-4 gx-lg-5 justify-content-center">


### PR DESCRIPTION
## Summary
- remove `header.masthead` sections from all pages
- keep the page titles as simple headings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687fd377d88083239c7d58cc8fba7b12