### PR TITLE
Add canonical and alternate links

### DIFF
--- a/aikidorol.html
+++ b/aikidorol.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Az aikidoról - Misogi Aikido Dojo">
+    <link rel="canonical" href="https://example.com/aikidorol.html">
+    <link rel="alternate" hreflang="hu" href="https://example.com/aikidorol.html">
+    <link rel="alternate" hreflang="en" href="https://example.com/aikidorol_en.html">
     <title>Aikidoról</title>
     <link rel="icon" type="image/png" href="assets/img/logo.png" />
     <script src="https://use.fontawesome.com/releases/v6.3.0/js/all.js" crossorigin="anonymous"></script>

--- a/aikidorol_en.html
+++ b/aikidorol_en.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="About Aikido - Misogi Aikido Dojo">
+    <link rel="canonical" href="https://example.com/aikidorol_en.html">
+    <link rel="alternate" hreflang="hu" href="https://example.com/aikidorol.html">
+    <link rel="alternate" hreflang="en" href="https://example.com/aikidorol_en.html">
     <title>About Aikido</title>
     <link rel="icon" type="image/png" href="assets/img/logo.png" />
     <script src="https://use.fontawesome.com/releases/v6.3.0/js/all.js" crossorigin="anonymous"></script>

--- a/gallery.html
+++ b/gallery.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Galéria - Misogi Aikido Dojo">
+    <link rel="canonical" href="https://example.com/gallery.html">
+    <link rel="alternate" hreflang="hu" href="https://example.com/gallery.html">
+    <link rel="alternate" hreflang="en" href="https://example.com/gallery_en.html">
     <title>Galéria</title>
     <link rel="icon" type="image/png" href="assets/img/logo.png" />
     <script src="https://use.fontawesome.com/releases/v6.3.0/js/all.js" crossorigin="anonymous"></script>

--- a/gallery.php
+++ b/gallery.php
@@ -18,6 +18,9 @@ $videoFiles = file_exists($videoDir) ? list_files($videoDir, '/\.(mp4|webm|ogg|a
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Galéria - Misogi Aikido Dojo">
+    <link rel="canonical" href="https://example.com/gallery.php">
+    <link rel="alternate" hreflang="hu" href="https://example.com/gallery.php">
+    <link rel="alternate" hreflang="en" href="https://example.com/gallery_en.php">
     <title>Galéria</title>
     <link rel="icon" type="image/png" href="assets/img/logo.png" />
     <script src="https://use.fontawesome.com/releases/v6.3.0/js/all.js" crossorigin="anonymous"></script>

--- a/gallery_en.html
+++ b/gallery_en.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Gallery - Misogi Aikido Dojo">
+    <link rel="canonical" href="https://example.com/gallery_en.html">
+    <link rel="alternate" hreflang="hu" href="https://example.com/gallery.html">
+    <link rel="alternate" hreflang="en" href="https://example.com/gallery_en.html">
     <title>Gallery</title>
     <link rel="icon" type="image/png" href="assets/img/logo.png" />
     <script src="https://use.fontawesome.com/releases/v6.3.0/js/all.js" crossorigin="anonymous"></script>

--- a/gallery_en.php
+++ b/gallery_en.php
@@ -18,6 +18,9 @@ $videoFiles = file_exists($videoDir) ? list_files($videoDir, '/\.(mp4|webm|ogg|a
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Gallery - Misogi Aikido Dojo">
+    <link rel="canonical" href="https://example.com/gallery_en.php">
+    <link rel="alternate" hreflang="hu" href="https://example.com/gallery.php">
+    <link rel="alternate" hreflang="en" href="https://example.com/gallery_en.php">
     <title>Gallery</title>
     <link rel="icon" type="image/png" href="assets/img/logo.png" />
     <script src="https://use.fontawesome.com/releases/v6.3.0/js/all.js" crossorigin="anonymous"></script>

--- a/helyszin.html
+++ b/helyszin.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Helyszín - Misogi Aikido Dojo edzések">
+    <link rel="canonical" href="https://example.com/helyszin.html">
+    <link rel="alternate" hreflang="hu" href="https://example.com/helyszin.html">
+    <link rel="alternate" hreflang="en" href="https://example.com/helyszin_en.html">
     <title>Helyszín</title>
     <link rel="icon" type="image/png" href="assets/img/logo.png" />
     <script src="https://use.fontawesome.com/releases/v6.3.0/js/all.js" crossorigin="anonymous"></script>

--- a/helyszin_en.html
+++ b/helyszin_en.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Location - Misogi Aikido Dojo">
+    <link rel="canonical" href="https://example.com/helyszin_en.html">
+    <link rel="alternate" hreflang="hu" href="https://example.com/helyszin.html">
+    <link rel="alternate" hreflang="en" href="https://example.com/helyszin_en.html">
     <title>Location</title>
     <link rel="icon" type="image/png" href="assets/img/logo.png" />
     <script src="https://use.fontawesome.com/releases/v6.3.0/js/all.js" crossorigin="anonymous"></script>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Misogi Aikido Dojo kezdő csoport toborzás">
+    <link rel="canonical" href="https://example.com/index.html">
+    <link rel="alternate" hreflang="hu" href="https://example.com/index.html">
+    <link rel="alternate" hreflang="en" href="https://example.com/index_en.html">
     <title>Misogi Aikido Dojo</title>
     <link rel="icon" type="image/png" href="assets/img/logo.png" />
     <script src="https://use.fontawesome.com/releases/v6.3.0/js/all.js" crossorigin="anonymous"></script>

--- a/index_en.html
+++ b/index_en.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Misogi Aikido Dojo recruitment">
+    <link rel="canonical" href="https://example.com/index_en.html">
+    <link rel="alternate" hreflang="hu" href="https://example.com/index.html">
+    <link rel="alternate" hreflang="en" href="https://example.com/index_en.html">
     <title>Misogi Aikido Dojo</title>
     <link rel="icon" type="image/png" href="assets/img/logo.png" />
     <script src="https://use.fontawesome.com/releases/v6.3.0/js/all.js" crossorigin="anonymous"></script>

--- a/jelentkezes.html
+++ b/jelentkezes.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Jelentkezés - Misogi Aikido Dojo">
+    <link rel="canonical" href="https://example.com/jelentkezes.html">
+    <link rel="alternate" hreflang="hu" href="https://example.com/jelentkezes.html">
+    <link rel="alternate" hreflang="en" href="https://example.com/jelentkezes_en.html">
     <title>Jelentkezés</title>
     <link rel="icon" type="image/png" href="assets/img/logo.png" />
     <script src="https://use.fontawesome.com/releases/v6.3.0/js/all.js" crossorigin="anonymous"></script>

--- a/jelentkezes_en.html
+++ b/jelentkezes_en.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Application - Misogi Aikido Dojo">
+    <link rel="canonical" href="https://example.com/jelentkezes_en.html">
+    <link rel="alternate" hreflang="hu" href="https://example.com/jelentkezes.html">
+    <link rel="alternate" hreflang="en" href="https://example.com/jelentkezes_en.html">
     <title>Apply</title>
     <link rel="icon" type="image/png" href="assets/img/logo.png" />
     <script src="https://use.fontawesome.com/releases/v6.3.0/js/all.js" crossorigin="anonymous"></script>

--- a/kapcsolat.html
+++ b/kapcsolat.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Kapcsolat - Misogi Aikido Dojo">
+    <link rel="canonical" href="https://example.com/kapcsolat.html">
+    <link rel="alternate" hreflang="hu" href="https://example.com/kapcsolat.html">
+    <link rel="alternate" hreflang="en" href="https://example.com/kapcsolat_en.html">
     <title>Kapcsolat</title>
     <link rel="icon" type="image/png" href="assets/img/logo.png" />
     <script src="https://use.fontawesome.com/releases/v6.3.0/js/all.js" crossorigin="anonymous"></script>

--- a/kapcsolat_en.html
+++ b/kapcsolat_en.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Contact - Misogi Aikido Dojo">
+    <link rel="canonical" href="https://example.com/kapcsolat_en.html">
+    <link rel="alternate" hreflang="hu" href="https://example.com/kapcsolat.html">
+    <link rel="alternate" hreflang="en" href="https://example.com/kapcsolat_en.html">
     <title>Contact</title>
     <link rel="icon" type="image/png" href="assets/img/logo.png" />
     <script src="https://use.fontawesome.com/releases/v6.3.0/js/all.js" crossorigin="anonymous"></script>

--- a/praktikus.html
+++ b/praktikus.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Praktikus kérdések - Misogi Aikido Dojo">
+    <link rel="canonical" href="https://example.com/praktikus.html">
+    <link rel="alternate" hreflang="hu" href="https://example.com/praktikus.html">
+    <link rel="alternate" hreflang="en" href="https://example.com/praktikus_en.html">
     <title>Praktikus kérdések</title>
     <link rel="icon" type="image/png" href="assets/img/logo.png" />
     <script src="https://use.fontawesome.com/releases/v6.3.0/js/all.js" crossorigin="anonymous"></script>

--- a/praktikus_en.html
+++ b/praktikus_en.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Practical questions - Misogi Aikido Dojo">
+    <link rel="canonical" href="https://example.com/praktikus_en.html">
+    <link rel="alternate" hreflang="hu" href="https://example.com/praktikus.html">
+    <link rel="alternate" hreflang="en" href="https://example.com/praktikus_en.html">
     <title>Practical questions</title>
     <link rel="icon" type="image/png" href="assets/img/logo.png" />
     <script src="https://use.fontawesome.com/releases/v6.3.0/js/all.js" crossorigin="anonymous"></script>

--- a/rolunk.html
+++ b/rolunk.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Rólunk - Misogi Aikido Dojo bemutatkozás">
+    <link rel="canonical" href="https://example.com/rolunk.html">
+    <link rel="alternate" hreflang="hu" href="https://example.com/rolunk.html">
+    <link rel="alternate" hreflang="en" href="https://example.com/rolunk_en.html">
     <title>Rólunk</title>
     <link rel="icon" type="image/png" href="assets/img/logo.png" />
     <script src="https://use.fontawesome.com/releases/v6.3.0/js/all.js" crossorigin="anonymous"></script>

--- a/rolunk_en.html
+++ b/rolunk_en.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="About us - Misogi Aikido Dojo">
+    <link rel="canonical" href="https://example.com/rolunk_en.html">
+    <link rel="alternate" hreflang="hu" href="https://example.com/rolunk.html">
+    <link rel="alternate" hreflang="en" href="https://example.com/rolunk_en.html">
     <title>About Us</title>
     <link rel="icon" type="image/png" href="assets/img/logo.png" />
     <script src="https://use.fontawesome.com/releases/v6.3.0/js/all.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Summary
- add canonical and alternate hreflang links after meta tags for all HTML and PHP pages

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687feccb710c83238f15a8fdd43d54c8