### PR TITLE
Remove duplicate closing div in index pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,6 @@
     <!-- Navigation-->
 
 <div id="navbar-placeholder"></div>
-</div>
 
     <!-- Main Content-->
     <main>

--- a/index_en.html
+++ b/index_en.html
@@ -35,7 +35,6 @@
 <body>
 
 <div id="navbar-placeholder"></div>
-</div>
 
     <main>
         <div class="container px-4 px-lg-5">


### PR DESCRIPTION
## Summary
- remove stray `</div>` after `navbar-placeholder` in `index.html` and `index_en.html`

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_687ffce0cdd08323a298e83f744e9786