### PR TITLE
Fix location page labels and BKK link placement

### DIFF
--- a/helyszin.html
+++ b/helyszin.html
@@ -42,9 +42,10 @@
                 <div class="col-md-10 col-lg-8 col-xl-7">
                     <section>
                         <h2>Bárdos Lajos Általános Iskola tornaterme</h2>
-                        <p>1107 Budapest, Baranyai utca 16-18.</p>
+                        <p><strong>Helyszín:</strong> 1107 Budapest, Baranyai utca 16-18.</p>
                         <p>Telefon: +36 30 940-7083</p>
                         <p>E-mail: <a href="mailto:misogi@aikido.hu">misogi@aikido.hu</a></p>
+                        <p><a href="https://futar.bkk.hu/?toCoord=47.472414%2C19.049024&toName=Baranyai%20utca%2016.&toSubName=Budapest%201117&toDisplayName=Baranyai%20utca%2016.%2C%20Budapest%201117" target="_blank">BKK Futár</a></p>
                     </section>
                 </div>
             </div>
@@ -57,16 +58,6 @@
                 referrerpolicy="no-referrer-when-downgrade"
                 allowfullscreen="">
             </iframe>
-        </div>
-        <div class="container px-4 px-lg-5">
-            <div class="row gx-4 gx-lg-5 justify-content-center">
-                <div class="col-md-10 col-lg-8 col-xl-7">
-                    <section>
-
-                        <p><a href="https://futar.bkk.hu/?toCoord=47.472414%2C19.049024&toName=Baranyai%20utca%2016.&toSubName=Budapest%201117&toDisplayName=Baranyai%20utca%2016.%2C%20Budapest%201117" target="_blank">BKK Futár</a></p>
-                    </section>
-                </div>
-            </div>
         </div>
     </main>
     <footer class="border-top">


### PR DESCRIPTION
## Summary
- add `Helyszín` label in front of the address on the Helyszín page
- move the BKK Futár link under the email line and above the map

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6880059a4930832381dfeb7452a5fe03