### PR TITLE
Remove Helyszín from navbar

### DIFF
--- a/stable_navbar.html
+++ b/stable_navbar.html
@@ -23,7 +23,6 @@
                 </div>
                 <div class="hidden md:flex items-center space-x-6">
                     <a href="#" class="text-red-600 hover:text-red-400">Rólunk</a>
-                    <a href="#" class="text-red-600 hover:text-red-400">Helyszín</a>
                     <a href="#" class="text-red-600 hover:text-red-400">Kapcsolat</a>
                 </div>
                 <button id="menu-toggle" class="md:hidden text-red-600 focus:outline-none">
@@ -34,7 +33,6 @@
         <div id="mobile-menu" class="md:hidden bg-white">
             <div class="px-4 pt-2 pb-4 space-y-1">
                 <a href="#" class="block text-red-600 py-2">Rólunk</a>
-                <a href="#" class="block text-red-600 py-2">Helyszín</a>
                 <a href="#" class="block text-red-600 py-2">Kapcsolat</a>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- drop the `Helyszín` links from `stable_navbar.html`

## Testing
- `grep -n "Helyszín" -n stable_navbar.html`

------
https://chatgpt.com/codex/tasks/task_e_68800bf516608323aae18fe5ce2fa7bb