### PR TITLE
Add hero images to home page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -108,3 +108,57 @@ img.rounded {
   transform: scale(0.92);
 }
 
+/* hero images on the homepage */
+.hero-images {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.hero-image {
+  flex: 0 0 30%;
+  max-width: 200px;
+  height: 200px;
+  margin: 0;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.3s ease;
+}
+
+.hero-image:hover img {
+  transform: scale(1.05);
+}
+
+.hero-image figcaption {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: white;
+  text-align: center;
+  pointer-events: none;
+  text-shadow: 0 0 5px rgba(0, 0, 0, 0.8);
+}
+
+.hero-image .long-text {
+  display: block;
+  opacity: 0;
+  background: rgba(0, 0, 0, 0.6);
+  padding: 0.5rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+  transition: opacity 0.3s ease;
+}
+
+.hero-image:hover .long-text {
+  opacity: 1;
+}
+

--- a/index.html
+++ b/index.html
@@ -38,6 +38,29 @@
 
     <!-- Main Content-->
     <main>
+        <section class="hero-images">
+            <figure class="hero-image">
+                <img src="resources/other/kanji Ai.gif" alt="Ai kanji">
+                <figcaption>
+                    <span class="short-text">Harmónia</span>
+                    <span class="long-text">Az Aikidó célja nem a pusztítás, hanem az összhang keresése a támadóval – fizikai és lelki szinten is.</span>
+                </figcaption>
+            </figure>
+            <figure class="hero-image">
+                <img src="resources/other/kanji Ki.gif" alt="Ki kanji">
+                <figcaption>
+                    <span class="short-text">Energia</span>
+                    <span class="long-text">Az életet átható energia, amit irányítani és érzékelni lehet. A gyakorló megtanulja érzékelni a támadó „ki”-jét, és azt nem megtörni, hanem elvezetni.</span>
+                </figcaption>
+            </figure>
+            <figure class="hero-image">
+                <img src="resources/other/kanji Do.gif" alt="Do kanji">
+                <figcaption>
+                    <span class="short-text">Életfilozófia</span>
+                    <span class="long-text">Az aikidó nem pusztán technikai tudás, hanem szellemi út is.</span>
+                </figcaption>
+            </figure>
+        </section>
         <div class="container px-4 px-lg-5">
             <div class="row gx-4 gx-lg-5 justify-content-center">
                 <div class="col-md-10 col-lg-8 col-xl-7">


### PR DESCRIPTION
## Summary
- add a new hero section on the home page with three kanji images
- show captions with short and long text
- style hero section with hover effect
- resize hero cards and update Hungarian captions

## Testing
- `npx --yes htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_6880df1424d48323a51ceae4d51b5db0