### PR TITLE
Add hero images to home page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -108,3 +108,50 @@ img.rounded {
   transform: scale(0.92);
 }
 
+/* hero images on the homepage */
+.hero-images {
+  display: flex;
+  justify-content: center;
+  gap: 0;
+}
+
+.hero-image {
+  flex: 1 1 33%;
+  height: 200px;
+  margin: 0;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.3s ease;
+}
+
+.hero-image:hover img {
+  transform: scale(1.05);
+}
+
+.hero-image figcaption {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: white;
+  text-align: center;
+  pointer-events: none;
+  text-shadow: 0 0 5px rgba(0, 0, 0, 0.8);
+}
+
+.hero-description {
+  margin-top: 1rem;
+  text-align: center;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+  font-size: 0.9rem;
+}
+

--- a/index.html
+++ b/index.html
@@ -38,6 +38,21 @@
 
     <!-- Main Content-->
     <main>
+        <section class="hero-images">
+            <figure class="hero-image" data-long-text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec ipsum convallis, luctus nisl a, tincidunt mi. Aenean.">
+                <img src="resources/other/kanji Ai.gif" alt="Ai kanji">
+                <figcaption>Harmónia</figcaption>
+            </figure>
+            <figure class="hero-image" data-long-text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec ipsum convallis, luctus nisl a, tincidunt mi. Aenean.">
+                <img src="resources/other/kanji Ki.gif" alt="Ki kanji">
+                <figcaption>Energia</figcaption>
+            </figure>
+            <figure class="hero-image" data-long-text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec ipsum convallis, luctus nisl a, tincidunt mi. Aenean.">
+                <img src="resources/other/kanji Do.gif" alt="Do kanji">
+                <figcaption>Életfilozófia</figcaption>
+            </figure>
+        </section>
+        <div id="hero-description" class="hero-description"></div>
         <div class="container px-4 px-lg-5">
             <div class="row gx-4 gx-lg-5 justify-content-center">
                 <div class="col-md-10 col-lg-8 col-xl-7">
@@ -82,5 +97,17 @@
     <!-- Bootstrap core JS-->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="dist/js/scripts.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const descEl = document.getElementById('hero-description');
+            const figures = document.querySelectorAll('.hero-image');
+            if (!descEl || figures.length === 0) return;
+            const showText = (e) => {
+                descEl.textContent = e.currentTarget.dataset.longText;
+            };
+            figures.forEach(fig => fig.addEventListener('mouseenter', showText));
+            descEl.textContent = figures[0].dataset.longText;
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a new hero section on the home page with three kanji images
- show captions with short text and display longer text in separate div when hovering
- style hero section without gaps between images
- update script to switch text under the images

## Testing
- `npx --yes htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_6880df1424d48323a51ceae4d51b5db0