### PR TITLE
Display hero long text on click

### DIFF
--- a/dist/js/scripts.js
+++ b/dist/js/scripts.js
@@ -57,7 +57,7 @@ window.addEventListener("DOMContentLoaded", () => {
     const showText = (e) => {
       descEl.textContent = e.currentTarget.dataset.longText;
     };
-    figures.forEach((fig) => fig.addEventListener("mouseenter", showText));
+    figures.forEach((fig) => fig.addEventListener("click", showText));
     descEl.textContent = figures[0].dataset.longText;
   };
 

--- a/index.html
+++ b/index.html
@@ -51,21 +51,21 @@
       <section class="hero-images">
         <figure
           class="hero-image"
-          data-long-text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec ipsum convallis, luctus nisl a, tincidunt mi. Aenean."
+          data-long-text="Az 'ai' kanji jelentése harmónia, összhang. Az aikidó célja, hogy a támadó erőt úgy térítsük el, hogy az együttműködésen alapuló egység jöjjön létre."
         >
           <img src="resources/other/kanji Ai.gif" alt="Ai kanji" />
           <figcaption>Harmónia</figcaption>
         </figure>
         <figure
           class="hero-image"
-          data-long-text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec ipsum convallis, luctus nisl a, tincidunt mi. Aenean."
+          data-long-text="A 'ki' az életenergia, amely minden mozdulat lelke. Az aikidó gyakorlása fejleszti és tudatosítja ezt a belső erőt, hogy hatékonyan irányíthassuk."
         >
           <img src="resources/other/kanji Ki.gif" alt="Ki kanji" />
           <figcaption>Energia</figcaption>
         </figure>
         <figure
           class="hero-image"
-          data-long-text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec ipsum convallis, luctus nisl a, tincidunt mi. Aenean."
+          data-long-text="A 'dó' útat jelent: az aikidó nem csupán technikák sora, hanem életfilozófia, mely folyamatos fejlődésre és önismeretre ösztönöz."
         >
           <img src="resources/other/kanji Do.gif" alt="Do kanji" />
           <figcaption>Életfilozófia</figcaption>


### PR DESCRIPTION
## Summary
- show hero description when clicking the image instead of on hover
- replace lorem ipsum hero texts with real descriptions

## Testing
- `tidy -errors index.html`
- `jshint dist/js/scripts.js` *(fails: ES6 syntax warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6880f3382da48323a66b29caadaffb77