### PR TITLE
Fix BKK Futár links

### DIFF
--- a/kapcsolat.html
+++ b/kapcsolat.html
@@ -33,7 +33,7 @@
                         </ul>
                         <p>Edzések időpontja: Hétfő, Csütörtök, 18.00 - 20.30</p>
                         <p>Tagdíj: 20 eFt/hó - az első hónap díjmentes</p>
-                        <p>Útvonal tervezés: <a href="https://futar.bkk.hu/?toCoord=47.472414%2C19.049024&toName=Baranyai%20utca%2016.&toSubName=Budapest%201117&toDisplayName=Baranyai%20utca%2016.%2C%20Budapest%201117" target="_blank">BKK Futár (BudapestGO)</a></p>
+                        <p>Útvonal tervezés: <a href="https://futar.bkk.hu/?toCoord=47.472414%2C19.049024&toName=Baranyai%20utca%2016.&toSubName=Budapest%201117&toDisplayName=Baranyai%20utca%2016.%2C%20Budapest%201117#map=19/47.472414/19.049024" target="_blank">BKK Futár (BudapestGO)</a></p>
                     </section>
                 </div>
             </div>

--- a/kapcsolat_en.html
+++ b/kapcsolat_en.html
@@ -33,7 +33,7 @@
                         </ul>
                         <p>Training times: Monday, Thursday, 18:00 - 20:30</p>
                         <p>Membership fee: 20k HUF/month – first month free</p>
-                        <p>Route planner: <a href="https://futar.bkk.hu/?toCoord=47.472414%2C19.049024&toName=Baranyai%20utca%2016.&toSubName=Budapest%201117&toDisplayName=Baranyai%20utca%2016.%2C%20Budapest%201117" target="_blank">BKK Futár (BudapestGO)</a></p>
+                        <p>Route planner: <a href="https://futar.bkk.hu/?toCoord=47.472414%2C19.049024&toName=Baranyai%20utca%2016.&toSubName=Budapest%201117&toDisplayName=Baranyai%20utca%2016.%2C%20Budapest%201117#map=19/47.472414/19.049024" target="_blank">BKK Futár (BudapestGO)</a></p>
                     </section>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- update the route planner links on the Hungarian and English contact pages so BudapestGO focuses on the dojo location

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6881244202a48323bb11d03c10c467e5