### PR TITLE
Swap nav bar order and fix spelling

### DIFF
--- a/navbar_en.html
+++ b/navbar_en.html
@@ -8,8 +8,8 @@
         <div class="collapse navbar-collapse" id="navbarResponsive">
             <ul class="navbar-nav ms-auto py-4 py-lg-0">
                 <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="index_en.html">Home</a></li>
-                <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="rolunk_en.html">About Us</a></li>
                 <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="aikidorol_en.html">About Aikido</a></li>
+                <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="rolunk_en.html">About Us</a></li>
                 <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="kapcsolat_en.html">Contact</a></li>
                 <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="jelentkezes_en.html">Apply</a></li>
                 <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="praktikus_en.html">Practical questions</a></li>

--- a/navbar_hu.html
+++ b/navbar_hu.html
@@ -8,8 +8,8 @@
         <div class="collapse navbar-collapse" id="navbarResponsive">
             <ul class="navbar-nav ms-auto py-4 py-lg-0">
                 <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="index.html">Kezdőlap</a></li>
+                <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="aikidorol.html">Aikidoról</a></li>
                 <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="rolunk.html">Rólunk</a></li>
-                <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="aikidorol.html">Aikidóról</a></li>
                 <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="kapcsolat.html">Kapcsolat</a></li>
                 <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="jelentkezes.html">Jelentkezés</a></li>
                 <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="praktikus.html">Praktikus kérdések</a></li>


### PR DESCRIPTION
## Summary
- swap order of "Aikidóról" and "Rólunk" menu items
- fix label to "Aikidoról"
- update English nav to list "About Aikido" before "About Us"

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68812a2510d88323836fd551b102449d