### PR TITLE
Initialize hero images in external script

### DIFF
--- a/aikidorol.html
+++ b/aikidorol.html
@@ -60,17 +60,5 @@
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="dist/js/scripts.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const descEl = document.getElementById('hero-description');
-            const figures = document.querySelectorAll('.hero-image');
-            if (!descEl || figures.length === 0) return;
-            const showText = (e) => {
-                descEl.textContent = e.currentTarget.dataset.longText;
-            };
-            figures.forEach(fig => fig.addEventListener('click', showText));
-            descEl.textContent = figures[0].dataset.longText;
-        });
-    </script>
 </body>
 </html>

--- a/aikidorol_en.html
+++ b/aikidorol_en.html
@@ -60,17 +60,5 @@
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="dist/js/scripts.js"></script>
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const descEl = document.getElementById('hero-description');
-            const figures = document.querySelectorAll('.hero-image');
-            if (!descEl || figures.length === 0) return;
-            const showText = (e) => {
-                descEl.textContent = e.currentTarget.dataset.longText;
-            };
-            figures.forEach(fig => fig.addEventListener('click', showText));
-            descEl.textContent = figures[0].dataset.longText;
-        });
-    </script>
 </body>
 </html>

--- a/dist/js/scripts.js
+++ b/dist/js/scripts.js
@@ -48,6 +48,17 @@ window.addEventListener('DOMContentLoaded', () => {
         });
     };
 
+    const initHeroImages = () => {
+        const descEl = document.getElementById('hero-description');
+        const figures = document.querySelectorAll('.hero-image');
+        if (!descEl || figures.length === 0) return;
+        const showText = (e) => {
+            descEl.textContent = e.currentTarget.dataset.longText;
+        };
+        figures.forEach(fig => fig.addEventListener('click', showText));
+        descEl.textContent = figures[0].dataset.longText;
+    };
+
     const initNavScroll = (mainNav) => {
         let scrollPos = 0;
         const headerHeight = mainNav.clientHeight;
@@ -166,6 +177,7 @@ window.addEventListener('DOMContentLoaded', () => {
                     history.pushState({}, '', url);
                 }
                 window.scrollTo(0, 0);
+                initHeroImages();
             });
     };
 
@@ -173,5 +185,6 @@ window.addEventListener('DOMContentLoaded', () => {
     loadNav(navFile).then(() => {
         initSpa();
         updateActiveNav(location.pathname.replace(/^\//, '') || 'index.html');
+        initHeroImages();
     });
 });


### PR DESCRIPTION
## Summary
- add `initHeroImages` to `scripts.js` to manage description updates
- invoke hero-image initialization on page load and after SPA navigation
- remove duplicated inline scripts from `aikidorol.html` and `aikidorol_en.html`

## Testing
- `npm test` *(fails: no `package.json` present)*

------
https://chatgpt.com/codex/tasks/task_e_688136c00d9883239be61d500ec79322