### PR TITLE
Initialize gallery lightbox when available

### DIFF
--- a/dist/js/scripts.js
+++ b/dist/js/scripts.js
@@ -178,6 +178,9 @@ window.addEventListener('DOMContentLoaded', () => {
                 }
                 window.scrollTo(0, 0);
                 initHeroImages();
+                if (document.querySelector('.gallery-item')) {
+                    initLightbox();
+                }
             });
     };
 
@@ -186,5 +189,8 @@ window.addEventListener('DOMContentLoaded', () => {
         initSpa();
         updateActiveNav(location.pathname.replace(/^\//, '') || 'index.html');
         initHeroImages();
+        if (document.querySelector('.gallery-item')) {
+            initLightbox();
+        }
     });
 });


### PR DESCRIPTION
## Summary
- call `initLightbox` from `navigate` if a gallery exists
- perform the same lightbox check when the page first loads

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688137c6d79c83238fb270dfe7356d43