### PR TITLE
Add confirmation message for application form

### DIFF
--- a/dist/js/scripts.js
+++ b/dist/js/scripts.js
@@ -183,12 +183,28 @@ window.addEventListener('DOMContentLoaded', () => {
                 }
             });
     };
+    const initApplicationForm = () => {
+        const form = document.querySelector(".application-form");
+        const successEl = document.getElementById("application-success");
+        const testBtn = document.getElementById("test-success");
+        const showSuccess = () => {
+            if (!successEl) return;
+            successEl.classList.remove("d-none");
+            fadeIn(successEl);
+        };
+        if (form) {
+            form.addEventListener("submit", () => setTimeout(showSuccess, 100));
+        }
+        if (testBtn) testBtn.addEventListener("click", showSuccess);
+    };
+
 
     const navFile = lang === 'en' ? 'navbar_en.html' : 'navbar_hu.html';
     loadNav(navFile).then(() => {
         initSpa();
         updateActiveNav(location.pathname.replace(/^\//, '') || 'index.html');
         initHeroImages();
+        initApplicationForm();
         if (document.querySelector('.gallery-item')) {
             initLightbox();
         }

--- a/jelentkezes.html
+++ b/jelentkezes.html
@@ -25,7 +25,7 @@
                 <div class="col-md-10 col-lg-8 col-xl-7">
                     <section>
                         <h2>Jelentkezési űrlap</h2>
-                        <form action="mailto:misogi@aikido.hu" method="post" enctype="text/plain">
+                        <form class="application-form" action="mailto:misogi@aikido.hu" method="post" enctype="text/plain">
                             <div class="mb-3">
                                 <label class="form-label">Név
                                     <input class="form-control" type="text" name="name" required>
@@ -43,6 +43,8 @@
                             </div>
                             <button class="btn btn-primary" type="submit">Küldés</button>
                         </form>
+                            <div id="application-success" class="alert alert-success d-none mt-3" tabindex="-1">Köszönjük a jelentkezést! Hamarosan felvesszük Veled a kapcsolatot.</div>
+                            <button type="button" id="test-success" class="btn btn-secondary btn-sm mt-2">Teszt üzenet</button>
                     </section>
                 </div>
             </div>

--- a/jelentkezes_en.html
+++ b/jelentkezes_en.html
@@ -25,7 +25,7 @@
                 <div class="col-md-10 col-lg-8 col-xl-7">
                     <section>
                         <h2>Application form</h2>
-                        <form action="mailto:misogi@aikido.hu" method="post" enctype="text/plain">
+                        <form class="application-form" action="mailto:misogi@aikido.hu" method="post" enctype="text/plain">
                             <div class="mb-3">
                                 <label class="form-label">Name
                                     <input class="form-control" type="text" name="name" required>
@@ -43,6 +43,8 @@
                             </div>
                             <button class="btn btn-primary" type="submit">Send</button>
                         </form>
+                            <div id="application-success" class="alert alert-success d-none mt-3" tabindex="-1">Thank you for applying! We will get back to you soon.</div>
+                            <button type="button" id="test-success" class="btn btn-secondary btn-sm mt-2">Test message</button>
                     </section>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- show confirmation after sending the application form on both HU/EN pages
- expose a small test button for easier GitHub preview testing
- support the new feature in scripts.js

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68813e438b2c83238d9c22ca77553c39