### PR TITLE
Add Messenger contact link

### DIFF
--- a/kapcsolat.html
+++ b/kapcsolat.html
@@ -30,6 +30,7 @@
                         <ul>
                             <li>telefon: +36 30 940-7083</li>
                             <li>email: <a href="mailto:misogi@aikido.hu">misogi@aikido.hu</a></li>
+                            <li><a href="https://m.me/benedek.kiss.37" target="_blank">Írj nekem Messengerben</a></li>
                         </ul>
                         <p>Edzések időpontja: Hétfő, Csütörtök, 18.00 - 20.30</p>
                         <p>Tagdíj: 20 eFt/hó - az első hónap díjmentes</p>

--- a/kapcsolat_en.html
+++ b/kapcsolat_en.html
@@ -30,6 +30,7 @@
                         <ul>
                             <li>phone: +36 30 940-7083</li>
                             <li>email: <a href="mailto:misogi@aikido.hu">misogi@aikido.hu</a></li>
+                            <li><a href="https://m.me/benedek.kiss.37" target="_blank">Chat with me on Messenger</a></li>
                         </ul>
                         <p>Training times: Monday, Thursday, 18:00 - 20:30</p>
                         <p>Membership fee: 20k HUF/month – first month free</p>


### PR DESCRIPTION
## Summary
- link Facebook Messenger from contact page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688145915a80832382b925cb64bdf03e