### PR TITLE
Bold contact labels

### DIFF
--- a/kapcsolat.html
+++ b/kapcsolat.html
@@ -26,15 +26,15 @@
                     <section>
                         <h2>Misogi Aikido Dojo</h2>
                         <p><strong>Helyszín:</strong> 1107 Budapest, Baranyai utca 16-18. (az Allee közelében), Bárdos Lajos Általános Iskola tornaterme</p>
-                        <p>Klub neve: Misogi Aikido Dojo</p>
+                        <p><strong>Klub neve:</strong> Misogi Aikido Dojo</p>
                         <ul>
-                            <li>telefon: +36 30 940-7083</li>
-                            <li>email: <a href="mailto:misogi@aikido.hu">misogi@aikido.hu</a></li>
+                            <li><strong>telefon:</strong> +36 30 940-7083</li>
+                            <li><strong>email:</strong> <a href="mailto:misogi@aikido.hu">misogi@aikido.hu</a></li>
                             <li><a href="https://m.me/benedek.kiss.37" target="_blank">Írj nekünk Messengerben</a></li>
                         </ul>
-                        <p>Edzések időpontja: Hétfő, Csütörtök, 18.00 - 20.30</p>
-                        <p>Tagdíj: 20 eFt/hó - az első hónap díjmentes</p>
-                        <p>Útvonal tervezés: <a href="https://futar.bkk.hu/?toCoord=47.472414%2C19.049024&toName=Baranyai%20utca%2016.&toSubName=Budapest%201117&toDisplayName=Baranyai%20utca%2016.&map=15/47.47141/19.04873" target="_blank">BKK Futár (BudapestGO)</a></p>
+                        <p><strong>Edzések időpontja:</strong> Hétfő, Csütörtök, 18.00 - 20.30</p>
+                        <p><strong>Tagdíj:</strong> 20 eFt/hó - az első hónap díjmentes</p>
+                        <p><strong>Útvonal tervezés:</strong> <a href="https://futar.bkk.hu/?toCoord=47.472414%2C19.049024&toName=Baranyai%20utca%2016.&toSubName=Budapest%201117&toDisplayName=Baranyai%20utca%2016.&map=15/47.47141/19.04873" target="_blank">BKK Futár (BudapestGO)</a></p>
                     </section>
                 </div>
             </div>

--- a/kapcsolat_en.html
+++ b/kapcsolat_en.html
@@ -26,15 +26,15 @@
                     <section>
                         <h2>Misogi Aikido Dojo</h2>
                         <p><strong>Location:</strong> 1107 Budapest, Baranyai utca 16-18. (next to Allee), Gym of Bárdos Lajos Primary School</p>
-                        <p>Club name: Misogi Aikido Dojo</p>
+                        <p><strong>Club name:</strong> Misogi Aikido Dojo</p>
                         <ul>
-                            <li>phone: +36 30 940-7083</li>
-                            <li>email: <a href="mailto:misogi@aikido.hu">misogi@aikido.hu</a></li>
+                            <li><strong>phone:</strong> +36 30 940-7083</li>
+                            <li><strong>email:</strong> <a href="mailto:misogi@aikido.hu">misogi@aikido.hu</a></li>
                             <li><a href="https://m.me/benedek.kiss.37" target="_blank">Chat with us on Messenger</a></li>
                         </ul>
-                        <p>Training times: Monday, Thursday, 18:00 - 20:30</p>
-                        <p>Membership fee: 20k HUF/month – first month free</p>
-                        <p>Route planner: <a href="https://futar.bkk.hu/?toCoord=47.472414%2C19.049024&toName=Baranyai%20utca%2016.&toSubName=Budapest%201117&toDisplayName=Baranyai%20utca%2016.&map=15/47.47141/19.04873" target="_blank">BKK Futár (BudapestGO)</a></p>
+                        <p><strong>Training times:</strong> Monday, Thursday, 18:00 - 20:30</p>
+                        <p><strong>Membership fee:</strong> 20k HUF/month – first month free</p>
+                        <p><strong>Route planner:</strong> <a href="https://futar.bkk.hu/?toCoord=47.472414%2C19.049024&toName=Baranyai%20utca%2016.&toSubName=Budapest%201117&toDisplayName=Baranyai%20utca%2016.&map=15/47.47141/19.04873" target="_blank">BKK Futár (BudapestGO)</a></p>
                     </section>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- emphasize field labels before `:` on the Kontakt page
- mirror the same styling on the English Contact page

## Testing
- `git diff --color --unified=5`


------
https://chatgpt.com/codex/tasks/task_e_68814a4dbde883238d437e009ea4993b