### PR TITLE
Improve trainers table mobile layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -182,6 +182,23 @@ img.rounded {
   display: block;
 }
 
+@media (max-width: 576px) {
+  .profile-table,
+  .profile-table tbody,
+  .profile-table tr,
+  .profile-table td {
+    display: block;
+    width: 100%;
+  }
+  .profile-table tr {
+    margin-bottom: 1rem;
+  }
+  .profile-table td:first-child {
+    padding-right: 0;
+    text-align: center;
+  }
+}
+
 .events-table {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
## Summary
- stack trainer profiles vertically on small screens

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68814b560e048323af4e630d7d6ec8d7