### PR TITLE
Add dark mode toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3,7 +3,16 @@
   --color-beige: #ffffff; /* fehér, navbarhez igazítva */
   --color-green: #E63946; /* vermillion vörös */
   --color-green-hover: #e06363; /* világosabb hover árnyalat */
+  --color-row-alt: #f6f6f6; /* váltakozó sor háttér */
   --font-main: 'Garamond', serif;
+}
+
+:root[data-theme='dark'] {
+  --color-gray: #E2E8F0;
+  --color-beige: #1a202c;
+  --color-green: #E63946;
+  --color-green-hover: #ff7c7c;
+  --color-row-alt: #2d3748;
 }
 body {
   font-family: var(--font-main);
@@ -14,6 +23,7 @@ body {
   min-height: 100vh;
   padding-top: 5rem; /* Reserve space for the navbar */
   overflow-y: scroll; /* avoid scrollbar jumping */
+  transition: background-color 0.3s, color 0.3s;
 }
 
 h2 {
@@ -24,7 +34,7 @@ main {
   flex: 1 0 auto;
 }
 #mainNav {
-  background-color: #fff;
+  background-color: var(--color-beige);
   position: fixed;
   top: 0;
   width: 100%;
@@ -210,7 +220,7 @@ img.rounded {
 }
 
 .events-table tr:nth-child(even) {
-  background-color: #f6f6f6;
+  background-color: var(--color-row-alt);
 }
 
 .events-table th {

--- a/dist/js/scripts.js
+++ b/dist/js/scripts.js
@@ -7,6 +7,27 @@ window.addEventListener('DOMContentLoaded', () => {
     const getPlaceholder = () => document.getElementById('navbar-placeholder') || document.getElementById('mainNav');
     const lang = document.documentElement.lang;
 
+    const applySavedTheme = () => {
+        const saved = localStorage.getItem('theme');
+        if (saved) {
+            document.documentElement.dataset.theme = saved;
+        } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            document.documentElement.dataset.theme = 'dark';
+        }
+    };
+
+    const initThemeToggle = () => {
+        const btn = document.getElementById('theme-toggle');
+        if (!btn) return;
+        btn.addEventListener('click', (e) => {
+            e.preventDefault();
+            const html = document.documentElement;
+            const next = html.dataset.theme === 'dark' ? 'light' : 'dark';
+            html.dataset.theme = next;
+            localStorage.setItem('theme', next);
+        });
+    };
+
     const fadeDuration = 300;
     const fadeOut = (el) => {
         if (!el) return Promise.resolve();
@@ -96,6 +117,7 @@ window.addEventListener('DOMContentLoaded', () => {
                 if (mainNav) {
                     initNavScroll(mainNav);
                 }
+                initThemeToggle();
                 resolve();
             };
             if (cached) {
@@ -200,6 +222,7 @@ window.addEventListener('DOMContentLoaded', () => {
     };
 
 
+    applySavedTheme();
     const navFile = lang === 'en' ? 'navbar_en.html' : 'navbar_hu.html';
     loadNav(navFile).then(() => {
         initSpa();

--- a/navbar_en.html
+++ b/navbar_en.html
@@ -14,6 +14,7 @@
                 <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="jelentkezes_en.html">Apply</a></li>
                 <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="praktikus_en.html">Practical questions</a></li>
                 <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="gallery_en.php">Gallery</a></li>
+                <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="#" id="theme-toggle">Dark mode</a></li>
                 <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="index.html">Magyar</a></li>
             </ul>
         </div>

--- a/navbar_hu.html
+++ b/navbar_hu.html
@@ -14,6 +14,7 @@
                 <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="jelentkezes.html">Jelentkezés</a></li>
                 <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="praktikus.html">Praktikus kérdések</a></li>
                 <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="gallery.php">Galéria</a></li>
+                <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="#" id="theme-toggle">Sötét mód</a></li>
                 <li class="nav-item"><a class="nav-link px-lg-3 py-3 py-lg-4" href="index_en.html">English</a></li>
             </ul>
         </div>


### PR DESCRIPTION
## Summary
- add CSS variables and dark theme variant
- update navigation templates with a theme toggle link
- implement persistent dark mode logic in scripts

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68814c0e49948323aa6012d63afe3e56