### PR TITLE
Prevent mobile zoom by hiding horizontal overflow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -14,6 +14,7 @@ body {
   min-height: 100vh;
   padding-top: 5rem; /* Reserve space for the navbar */
   overflow-y: scroll; /* avoid scrollbar jumping */
+  overflow-x: hidden; /* prevent mobile zoom from horizontal overflow */
 }
 
 h2 {


### PR DESCRIPTION
## Summary
- hide horizontal overflow on the body element so the page width matches the viewport

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68814f232e348323868275228bff9448