### PR TITLE
Prevent mobile zoom by hiding overflow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5,6 +5,7 @@
   --color-green-hover: #e06363; /* világosabb hover árnyalat */
   --font-main: 'Garamond', serif;
 }
+html,
 body {
   font-family: var(--font-main);
   background: var(--color-beige);
@@ -14,6 +15,7 @@ body {
   min-height: 100vh;
   padding-top: 5rem; /* Reserve space for the navbar */
   overflow-y: scroll; /* avoid scrollbar jumping */
+  overflow-x: hidden; /* prevent mobile zoom from horizontal overflow */
 }
 
 h2 {


### PR DESCRIPTION
## Summary
- apply `overflow-x: hidden` to `html` along with `body`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68814f232e348323868275228bff9448