### PR TITLE
Add dojo location image to contact pages

### DIFF
--- a/kapcsolat.html
+++ b/kapcsolat.html
@@ -46,6 +46,8 @@
                 referrerpolicy="no-referrer-when-downgrade"
                 allowfullscreen="">
             </iframe>
+            <img src="resources/other/DojoHelyszin.png" alt="Dojo helyszín"
+                 class="img-fluid rounded mt-3" style="max-width: 600px; display:inline-block;" />
         </div>
     </main>
     <div id="footer-placeholder"></div>

--- a/kapcsolat_en.html
+++ b/kapcsolat_en.html
@@ -36,8 +36,9 @@
                 </div>
             </div>
         </div>
-        <div class="container-fluid p-0">
-            <iframe src="https://www.openstreetmap.org/export/embed.html?bbox=19.047024%2C47.471414%2C19.051024%2C47.473414&amp;layer=mapnik&amp;marker=47.472414%2C19.049024" style="border:0; width:100%; height:450px;" loading="lazy" referrerpolicy="no-referrer-when-downgrade" allowfullscreen=""></iframe>
+        <div class="container-fluid p-0 text-center">
+            <iframe src="https://www.openstreetmap.org/export/embed.html?bbox=19.047024%2C47.471414%2C19.051024%2C47.473414&amp;layer=mapnik&amp;marker=47.472414%2C19.049024" style="border:0; width:100%; height:450px; max-width:600px; display:inline-block;" loading="lazy" referrerpolicy="no-referrer-when-downgrade" allowfullscreen=""></iframe>
+            <img src="resources/other/DojoHelyszin.png" alt="Dojo location" class="img-fluid rounded mt-3" style="max-width:600px; display:inline-block;" />
         </div>
     </main>
     <div id="footer-placeholder"></div>


### PR DESCRIPTION
## Summary
- embed `DojoHelyszin.png` under the map on the Hungarian and English contact pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68866cd748a88323b9e27b52854fef6e