### PR TITLE
Fix contact page image layout

### DIFF
--- a/kapcsolat.html
+++ b/kapcsolat.html
@@ -47,7 +47,7 @@
                 allowfullscreen="">
             </iframe>
             <img src="resources/other/DojoHelyszin.png" alt="Dojo helyszín"
-                 class="img-fluid rounded mt-3" style="max-width: 600px; display:inline-block;" />
+                 class="img-fluid rounded mt-3" style="max-width: 600px; display:block; margin: 0 auto;" />
         </div>
     </main>
     <div id="footer-placeholder"></div>

--- a/kapcsolat_en.html
+++ b/kapcsolat_en.html
@@ -38,7 +38,7 @@
         </div>
         <div class="container-fluid p-0 text-center">
             <iframe src="https://www.openstreetmap.org/export/embed.html?bbox=19.047024%2C47.471414%2C19.051024%2C47.473414&amp;layer=mapnik&amp;marker=47.472414%2C19.049024" style="border:0; width:100%; height:450px; max-width:600px; display:inline-block;" loading="lazy" referrerpolicy="no-referrer-when-downgrade" allowfullscreen=""></iframe>
-            <img src="resources/other/DojoHelyszin.png" alt="Dojo location" class="img-fluid rounded mt-3" style="max-width:600px; display:inline-block;" />
+            <img src="resources/other/DojoHelyszin.png" alt="Dojo location" class="img-fluid rounded mt-3" style="max-width:600px; display:block; margin: 0 auto;" />
         </div>
     </main>
     <div id="footer-placeholder"></div>


### PR DESCRIPTION
## Summary
- make location map images display as blocks so they appear below the map

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886736bc3c08323a1794c409a60ddda