### PR TITLE
Fix contact page image responsiveness

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -201,3 +201,19 @@ img.rounded {
 
 /* NEM AI generált stílusok */
 
+/* Kontakt oldali kep mobiloptimalizalas */
+.contact-image {
+  display: block;
+  margin: 0 auto;
+  width: 100%;
+  max-width: 600px;
+  height: auto;
+}
+
+@media (max-width: 576px) {
+  .contact-image {
+    max-width: 100%;
+  }
+}
+
+

--- a/kapcsolat.html
+++ b/kapcsolat.html
@@ -47,7 +47,7 @@
                 allowfullscreen="">
             </iframe>
             <img src="resources/other/DojoHelyszin.png" alt="Dojo helyszín"
-                 class="img-fluid rounded mt-3" style="max-width: 600px; display:block; margin: 0 auto;" />
+                 class="img-fluid rounded mt-3 contact-image" />
         </div>
     </main>
     <div id="footer-placeholder"></div>

--- a/kapcsolat_en.html
+++ b/kapcsolat_en.html
@@ -38,7 +38,7 @@
         </div>
         <div class="container-fluid p-0 text-center">
             <iframe src="https://www.openstreetmap.org/export/embed.html?bbox=19.047024%2C47.471414%2C19.051024%2C47.473414&amp;layer=mapnik&amp;marker=47.472414%2C19.049024" style="border:0; width:100%; height:450px; max-width:600px; display:inline-block;" loading="lazy" referrerpolicy="no-referrer-when-downgrade" allowfullscreen=""></iframe>
-            <img src="resources/other/DojoHelyszin.png" alt="Dojo location" class="img-fluid rounded mt-3" style="max-width:600px; display:block; margin: 0 auto;" />
+            <img src="resources/other/DojoHelyszin.png" alt="Dojo location" class="img-fluid rounded mt-3 contact-image" />
         </div>
     </main>
     <div id="footer-placeholder"></div>


### PR DESCRIPTION
## Summary
- add `.contact-image` CSS to keep contact page images responsive
- update Hungarian and English contact pages to use the new class

## Testing
- `apt-get update` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_688a8440e3ac832394f7f5cddf0a99b9